### PR TITLE
Update build.gradle for fixing namespace issue during compile

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,8 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 34
+        namespace = "com.codenameakshay.async_wallpaper"
+
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
FAILURE: Build failed with an exception.

* What went wrong: A problem occurred configuring project ':async_wallpaper'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.  
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.